### PR TITLE
Add prepare script to allow npm to build at install time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "name": "Bruce Harrison"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "rollup -c",
     "test": "vitest",
     "lint": "eslint"


### PR DESCRIPTION
By adding a "prepare" script to your package.json we can add your repository as a dependency in our package.json
Then when we can install your code using npm:

`npm i  bruceharrison1984/bcrypt-edge`

this will install directly from GitHub. 

at install time locally, NPM will install your dependancies and then run the build step, then output the build folder into the consuming projects node_modules folder. 

Effectively this allows us to use your code as if we installed it from NPM directly. 

Check out this Blog post about it. 

https://blog.jim-nielsen.com/2018/installing-and-building-an-npm-package-from-github/

Very simple change to your package.json. 